### PR TITLE
Bugfix: Ownertag had 2 tags shown when someone had default owner tag by discord

### DIFF
--- a/style.css
+++ b/style.css
@@ -11,7 +11,7 @@
     color: inherit;
 }
 
-.ownerIcon-2NH9FM.icon-1A2_vz {
+[class*="ownerIcon-"][class*="icon-"] {
     display: none;
 }
 


### PR DESCRIPTION
Bug: 
![image](https://user-images.githubusercontent.com/58628835/157044969-af03cb3e-5e3d-4921-a0d1-ea913e86d932.png)

After fix:
![image](https://user-images.githubusercontent.com/58628835/157045088-ac048644-2380-453a-9ea7-daa53877f786.png)

Small bug, fixed with a style change.